### PR TITLE
docs: use `dart pub` instead of `pub`

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ This project uses [Melos](https://github.com/invertase/melos) to manage the proj
 To install Melos, run the following command from your SSH client:
 
 ```bash
-pub global activate melos
+dart pub global activate melos
 ```
 
 Next, at the root of your locally cloned repository bootstrap the projects dependencies:


### PR DESCRIPTION
The `pub` command was removed. Instead, we should use `dart pub`.